### PR TITLE
Bugfix: Feature descriptors can be None

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -254,10 +254,10 @@ measured in pixels. $c_x$ and $c_y$ are the principle points in the image coordi
 Since focal lengths of cameras are generally reported in mm, the method for converting is as follows:
 
 $$
-\begin{align*}
+\begin{aligned}
 f_x &= \frac{f\times w}{W} \\
 f_y &= \frac{f\times h}{H}
-\end{align*}
+\end{aligned}
 $$
 
 Where $f$ is the focal length measured in mm, $w$ is the image width in pixels, $W$ is the sensor width in mm,

--- a/mosaicking/utils.py
+++ b/mosaicking/utils.py
@@ -140,10 +140,6 @@ class VideoPlayer(cv2.VideoCapture):
         """Return true if stopping conditions met."""
         return self._finish_frame <= self.get(cv2.CAP_PROP_POS_FRAMES)
 
-    def __del__(self):
-        print(f"Closing video {self._args.video}")
-        self.release()
-
     def __len__(self):
         return len(range(*slice(self._start_frame, self._finish_frame, self.frame_skip).indices(self.n_frames)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "mosaic-library"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name="Fletcher Thompson", email="fletho@dtu.dk" },
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mosaic-library
-version = 1.0.1
+version = 1.0.2
 
 [options]
 packages = mosaicking

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,28 @@
+import unittest
+import numpy as np
+from mosaicking import registration
+import cv2
+
+
+class TestRegistrationModule(unittest.TestCase):
+    def setUp(self) -> None:
+        self._blank_image = np.zeros((100, 100), np.uint8)
+        # Create a black canvas
+        self._orb_image = np.zeros((500, 500), dtype=np.uint8)
+        # Draw some shapes on the image that are likely to produce ORB features
+        cv2.circle(self._orb_image, (200, 200), 50, (255, 255, 255), -1)
+        cv2.rectangle(self._orb_image, (300, 300), (400, 400), (255, 255, 255), -1)
+        cv2.line(self._orb_image, (100, 400), (400, 100), (255, 255, 255), 3)
+        self._detectors = cv2.SIFT_create(), cv2.ORB_create()
+
+    def test_get_keypoints_descriptors(self):
+        kp, des = registration.get_keypoints_descriptors(self._orb_image, self._detectors, None)
+        kp_blank, des_blank = registration.get_keypoints_descriptors(self._blank_image, self._detectors, None)
+        num_features = len(kp)
+        num_features_blank = len(kp_blank)
+        self.assertLess(num_features_blank, num_features)
+        self.assertEqual(num_features_blank, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refer to https://github.com/DTUAqua-ObsTek/mosaic-library/issues/4

If multiple features detectors used, then there is a chance one detector does not detect any features. The descriptors will have None appended to it, and result in error. Fixed with a conditional tuple comprehension.

Additional changes introduced:
- Removed the __del__ method from utils.VideoPlayer, since it sometimes results in segmentation faults.
- Moved some std_err warnings to the warnings.warn module.
- Optimal K obtained using cv2.getOptimalNewCalibrationMatrix
- Additional checks on images before writing them to file if mosaicking.mosaic finishes early / unexpectedly.
- Moved keypoint and descriptor detection steps in mosaicking.mosaic to mosaicking.registration.
- Added a unit test file for mosaicking.registration